### PR TITLE
Create PURPLE_PLUGIN_DIR if not existing

### DIFF
--- a/makefile
+++ b/makefile
@@ -47,6 +47,7 @@ lurch: $(SDIR)/lurch.c axc libomemo $(BDIR)
 	gcc -fPIC -shared $(CFLAGS) $(BDIR)/lurch.o $(FILES) -o $(BDIR)/lurch.so $(LFLAGS)
 	
 install: $(BDIR)/lurch.so
+	mkdir -p $(PURPLE_PLUGIN_DIR)
 	cp $(BDIR)/lurch.so $(PURPLE_PLUGIN_DIR)/lurch.so
 
 .PHONY: clean


### PR DESCRIPTION
The ~/.purple/plugin is not necessarily created already.