### PR TITLE
Improve build system

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 2. `cd lurch`
 3. `git submodule update --init` (If you just pull a newer version, remember to also update the submodules as they might have changed!)
 4. `make`
-5. A final `make install` should copy the compiled plugin into your libpurple plugin dir.
+5. A final `make install-home` should copy the compiled plugin into your libpurple plugin dir.
 6. The next time you start Pidgin (or another libpurple client), you should be able to activate it in the "Plugins" window.
 
 ### Windows


### PR DESCRIPTION
* respect system toolchain: gcc, pkg-config etc might be prefixed
* allow more control over passed flags, never overwriting CFLAGS etc
  entirely
* proper quoting: make does _not_ take care of quoting in make rules
* default "install" target installs into system plugin dir, additional
  "install-home" target installs into users home plugin dir
* simplify clean target and add "clean-all" target
* some minor changes to follow common Make style