### PR TITLE
Make the build dir an order-only prerequisite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ $(AXC_PATH):
 $(LOMEMO_PATH):
 	$(MAKE) -C "$(LOMEMO_DIR)" build/libomemo-conversations.a
 
-$(BDIR)/%.o: $(SDIR)/%.c $(BDIR)
+$(BDIR)/%.o: $(SDIR)/%.c | $(BDIR)
 	$(CC) -fPIC $(CFLAGS) $(CPPFLAGS) $(PLUGIN_CPPFLAGS) -c $(SDIR)/$*.c -o $@
 
 $(BDIR)/lurch.so: $(BDIR)/lurch.o $(VENDOR_LIBS)


### PR DESCRIPTION
Rebuilding used to happen when it shouldn't, for instance on `make
install` after `make`.

The "Types of Prerequisites" section of GNU make manual describes this
situation.