### PR TITLE
Add option for noobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Below you can find the command to install the dependencies for popular distribut
 
 __Debian, Ubuntu__
 ``` bash
-sudo apt install git cmake libpurple-dev libmxml-dev libxml2-dev libsqlite3-dev libgcrypt20-dev
+sudo apt install git cmake libpurple-dev libmxml-dev libxml2-dev libsqlite3-dev libgcrypt20-dev build-essential
 ```
 __ArchLinux, Parabola__
 ``` bash


### PR DESCRIPTION
If build-essential isn't installed on the system it complains about "No CMAKE_CXX_COMPILER could be found"