### PR TITLE
Report decryption failure to user

### DIFF
--- a/src/lurch.c
+++ b/src/lurch.c
@@ -1806,7 +1806,11 @@ static void lurch_message_decrypt(PurpleConnection * gc_p, xmlnode ** msg_stanza
     goto cleanup;
   }
   if (!key_p) {
+    const char *to = room_name ?: sender;
+
     purple_debug_info("lurch", "received omemo message that does not contain a key for this device, skipping\n");
+    purple_conv_present_error(to, purple_connection_get_account(gc_p),
+			      "Received omemo message that does not contain a key for this device");
     goto cleanup;
   }
 


### PR DESCRIPTION
This makes sure users know they're missing messages

I went for a specific error rather than just setting `err_msg_dbg` since this something the user should be able to act on (in contrast to other errors like `lurch_util_axc_get_init_ctx` failing