### PR TITLE
Use dynamically linked libraries axc and omemo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,10 +84,10 @@ AXC_PATH=$(AXC_BUILD)/libaxc-nt.a
 AX_DIR=$(AXC_DIR)/lib/libsignal-protocol-c
 AX_PATH=$(AX_DIR)/build/src/libsignal-protocol-c.a
 
-SOURCES := $(wildcard $(SDIR)/*.c)
+SOURCES := $(sort $(wildcard $(SDIR)/*.c))
 OBJECTS := $(patsubst $(SDIR)/%.c, $(BDIR)/%.o, $(SOURCES))
 OBJECTS_W_COVERAGE := $(patsubst $(SDIR)/%.c, $(BDIR)/%_w_coverage.o, $(SOURCES))
-TEST_SOURCES := $(wildcard $(TDIR)/test_*.c)
+TEST_SOURCES := $(sort $(wildcard $(TDIR)/test_*.c))
 TEST_OBJECTS := $(patsubst $(TDIR)/test_%.c, $(BDIR)/test_%.o, $(TEST_SOURCES))
 TEST_TARGETS := $(patsubst $(TDIR)/test_%.c, $(BDIR)/test_%, $(TEST_SOURCES))
 VENDOR_LIBS=$(LOMEMO_PATH) $(AXC_PATH) $(AX_PATH)

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ LIBPURPLE_CFLAGS=$(shell $(PKG_CONFIG) --cflags purple)
 PURPLE_DIR=$(shell $(PKG_CONFIG) --variable=plugindir purple)
 LIBPURPLE_LDFLAGS=$(shell $(PKG_CONFIG) --cflags purple) \
 		    -L$(PURPLE_DIR)
-		    
+
 XML2_CFLAGS ?= $(shell $(XML2_CONFIG) --cflags)
 XML2_LDFLAGS ?= $(shell $(XML2_CONFIG) --libs)
 
@@ -37,7 +37,7 @@ PKGCFG_C=$(GLIB_CFLAGS) \
 
 
 PKGCFG_L=$(shell $(PKG_CONFIG) --libs sqlite3 mxml) \
- 	$(GLIB_LDFLAGS) \
+	 $(GLIB_LDFLAGS) \
 	 $(LIBPURPLE_LDFLAGS) \
 	 $(XML2_LDFLAGS) \
 	 $(LIBGCRYPT_LDFLAGS)
@@ -58,7 +58,7 @@ PLUGIN_CPPFLAGS=-DPURPLE_PLUGINS
 # -D_BSD_SOURCE can be removed once nobody uses glibc <= 2.18 any more
 CPPFLAGS += -D_XOPEN_SOURCE=700 -D_BSD_SOURCE -D_DEFAULT_SOURCE
 LDFLAGS += -ldl -lm $(PKGCFG_L) $(LJABBER) -Wl,-rpath,$(PURPLE_PLUGIN_DIR)
-LDFLAGS_T=$(LDFLAGS) -lpurple -lcmocka 
+LDFLAGS_T=$(LDFLAGS) -lpurple -lcmocka
 
 ### directories
 #


### PR DESCRIPTION
Hi,

as part of the DebianOnMobile team, we are aiming at bringing lurch into debian. See the packaging [1] 
which is currently in the NEW queue.
This PR is related to [2] and [3]. In principle two things have been done to the Makefile:

- Switch to dynamically linked libraries for libaxc and libomemo. 
- Order the *.c files, so we can build reproducibly in debian (reprotest fails without this explicit ordering under the locale variation, because the `*.c` expansion will be locale dependent resulting in different ordering of the `rodata` and other segments in the compiled binary

Cheers

PS: I have seen that there are already pull requests [4] and [5]. ~~Would you be willing to carry the packaging from [1] upstream?~~

[1] https://salsa.debian.org/DebianOnMobile-team/purple-lurch
[2] https://github.com/gkdr/axc/pull/17
[3] https://github.com/gkdr/libomemo/pull/30
[4] https://github.com/gkdr/lurch/pull/136
[5] https://github.com/gkdr/lurch/pull/141
