### PR TITLE
Fix test failures

### DIFF
--- a/test/test_lurch_api.c
+++ b/test/test_lurch_api.c
@@ -248,6 +248,7 @@ static void lurch_api_id_remove_handler_cb_mock(int32_t err, void * user_data_p)
  */
 static void test_lurch_api_id_remove_handler(void ** state) {
     (void) state;
+    PurpleAccount p = { 0 };
 
     const char * test_jid = "me-testing@test.org/resource";
     will_return(__wrap_purple_account_get_username, test_jid);
@@ -274,7 +275,7 @@ static void test_lurch_api_id_remove_handler(void ** state) {
     expect_value(lurch_api_id_remove_handler_cb_mock, err, EXIT_SUCCESS);
     expect_value(lurch_api_id_remove_handler_cb_mock, user_data_p, test_user_data);
 
-    lurch_api_id_remove_handler((void *) "ignored", 1337, lurch_api_id_remove_handler_cb_mock, test_user_data);
+    lurch_api_id_remove_handler(&p, 1337, lurch_api_id_remove_handler_cb_mock, test_user_data);
 }
 
 /**

--- a/test/test_lurch_api.c
+++ b/test/test_lurch_api.c
@@ -31,8 +31,9 @@ int __wrap_omemo_storage_user_devicelist_retrieve(const char * user, const char 
     return ret_val;
 }
 
-void __wrap_purple_account_get_connection(PurpleAccount * acc_p) {
+void *__wrap_purple_account_get_connection(PurpleAccount * acc_p) {
     function_called();
+    return NULL;
 }
 
 void __wrap_purple_signal_register() {


### PR DESCRIPTION
This fixes test failutes on mipsel (and likely mips64el and armel), see

https://buildd.debian.org/status/fetch.php?pkg=purple-lurch&arch=armel&ver=0.6.8%2Bgit20200527.388605-2&stamp=1602096302&raw=0
https://buildd.debian.org/status/fetch.php?pkg=purple-lurch&arch=mips64el&ver=0.6.8%2Bgit20200527.388605-2&stamp=1602096208&raw=0
https://buildd.debian.org/status/fetch.php?pkg=purple-lurch&arch=mipsel&ver=0.6.8%2Bgit20200527.388605-2&stamp=1602096393&raw=0