### PR TITLE
makefile: use sh for test output filtering

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,4 +1,4 @@
-version: 0.6.9-dev-{build}
+version: 0.7.0-{build}
 
 image: Ubuntu1804
 

--- a/Makefile
+++ b/Makefile
@@ -192,7 +192,7 @@ $(BDIR)/test_lurch_util: $(OBJECTS_W_COVERAGE) $(VENDOR_LIBS) $(BDIR)/test_lurch
 	-Wl,--wrap=purple_debug_info \
 	-Wl,--wrap=purple_debug_misc \
 	-Wl,--wrap=purple_base16_encode_chunked
-	bash -c "set -o pipefail; $@ 2>&1 | grep -Ev ".*CRITICAL.*" | tr -s '\n'" # filter annoying and irrelevant glib output
+	sh -c "set -o pipefail; $@ 2>&1 | grep -Ev ".*CRITICAL.*" | tr -s '\n'" # filter annoying and irrelevant glib output
 
 $(BDIR)/test_lurch_api: $(OBJECTS_W_COVERAGE) $(VENDOR_LIBS) $(BDIR)/test_lurch_api.o
 	$(CC) $(CFLAGS) $(CPPFLAGS) -O0 --coverage $^ $(PURPLE_DIR)/libjabber.so.0 -o $@ $(LDFLAGS_T) \
@@ -217,7 +217,7 @@ $(BDIR)/test_lurch_api: $(OBJECTS_W_COVERAGE) $(VENDOR_LIBS) $(BDIR)/test_lurch_
 	-Wl,--wrap=omemo_storage_chatlist_exists \
 	-Wl,--wrap=omemo_storage_user_devicelist_retrieve \
 	-Wl,--wrap=lurch_util_fp_get_printable
-	bash -c "set -o pipefail; $@ 2>&1 | grep -Ev ".*CRITICAL.*" | tr -s '\n'" # filter annoying and irrelevant glib output
+	sh -c "set -o pipefail; $@ 2>&1 | grep -Ev ".*CRITICAL.*" | tr -s '\n'" # filter annoying and irrelevant glib output
 
 test: $(OBJECTS_W_COVERAGE) $(VENDOR_LIBS) $(TEST_TARGETS)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# lurch 0.6.9-dev
+# lurch 0.7.0
 /lʊʁç/. In German, an Axolotl is a type of Lurch, which simply means 'amphibian'. This plugin brings _Axolotl_, by now renamed to _double ratchet_, to _libpurple_ applications such as [Pidgin](https://www.pidgin.im/) by implementing the [XEP-0384: OMEMO Encryption](https://xmpp.org/extensions/xep-0384.html). For a higher-level overview, see [the official OMEMO homepage](https://conversations.im/omemo/).
 
 (Plus I thought the word sounds funny.)

--- a/src/lurch.h
+++ b/src/lurch.h
@@ -1,7 +1,7 @@
 #ifndef __LURCH_H
 # define __LURCH_H
 
-# define LURCH_VERSION "0.6.9-dev"
+# define LURCH_VERSION "0.7.0"
 # define LURCH_AUTHOR "Richard Bayerle <riba@firemail.cc>"
 
 #endif /* __LURCH_H */


### PR DESCRIPTION
There's nothing specific to bash here, and using sh will make this
compatible with systems that don't ship with bash (e.g. Alpine Linux)